### PR TITLE
Ops: only allow CRUD actions on S3 objects - no actions on buckets

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -8,9 +8,20 @@ provider:
   iamRoleStatements:
     - Effect: Allow
       Action:
-        - "s3:*"
-      Resource: "*"
-
+        - "s3:ListBucket"
+      Resource:
+        - "arn:aws:s3:::${self:custom.enrolmentBucket}"
+        - "arn:aws:s3:::${self:custom.callBackBucket}"
+        - "arn:aws:s3:::${self:custom.codeBucket}"
+    - Effect: Allow
+      Action:
+        - "s3:GetObject"
+        - "s3:PutObject"
+        - "s3:DeleteObject"
+      Resource:
+        - "arn:aws:s3:::${self:custom.enrolmentBucket}/*"
+        - "arn:aws:s3:::${self:custom.callBackBucket}/*"
+        - "arn:aws:s3:::${self:custom.codeBucket}/*"
 
 plugins:
   - serverless-python-requirements


### PR DESCRIPTION
Targeted at https://github.com/monkeypants/transferrable_aged_care_microcredentials/issues/107

Limits permissions given to the lambdas to only access, list, and update the files inside the S3 buckets.

Right, now both `employer-admin` and `employer-callback` have the same access to all available buckets `enrolmentBucket`, `callBackBucket`, and `codeBucket`. 
Should we limit their access more? maybe the `employer-admin` won't need to write to the `callbackBucket`?

I need a list of the actions that each service will need to perform on each bucket.